### PR TITLE
feat: add 1 year retention policy for cloudtrail

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -22,9 +22,24 @@ module "cloudtrail_bucket" {
   attach_policy           = true
   policy                  = data.aws_iam_policy_document.cloudtrail_bucket_policy.json
   tags                    = module.cloudtrail_label.tags
+
   versioning = {
     enabled = true
   }
+
+  lifecycle_rule = [
+    {
+      id      = "One year retention"
+      enabled = true
+      expiration = {
+        days = 360
+      }
+      noncurrent_version_expiration = {
+        days = 7
+      }
+    }
+  ]
+
 }
 
 data "aws_iam_policy_document" "cloudtrail_bucket_policy" {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds a `One year retention` lifecycle rule to avoid infinite growth of the bucket:

- Objects expire after 360 days
- Versions of objects after 7 days, as objects are logs only written once and versioning may only be useful tor restore accidental deletions.
- Storage class is always Standard, as objects are smaller than 10kbs and Std IA min size is 128kb and Glacier 40kb.

Fixes https://github.com/3scale/platform/issues/843

#### Notes

- https://aws.amazon.com/s3/storage-classes/?nc=sn&loc=3

/priority important-longterm
/assign